### PR TITLE
Migrate internal model to FHIR R5-native

### DIFF
--- a/demo/DemoForm.tsx
+++ b/demo/DemoForm.tsx
@@ -280,8 +280,7 @@ function ValueInput({ type, value, answerOptions, readOnly, linkId, onChange }: 
           onChange={(e) => onChange({ valueDate: e.target.value })}
         />
       );
-    case "choice":
-    case "open-choice":
+    case "coding":
       return (
         <>
           {answerOptions.map((opt) => (

--- a/demo/demo-form.ts
+++ b/demo/demo-form.ts
@@ -277,8 +277,7 @@ class DemoForm extends SignalWatcher(LitElement) {
         return html`<input type="date" .value=${val} ?readonly=${readonly}
           @input=${(e: Event) => onChange({ valueDate: (e.target as HTMLInputElement).value })} />`;
       }
-      case "choice":
-      case "open-choice": {
+      case "coding": {
         return html`
           ${answerOptions.map((opt) => {
             const label = optionDisplay(opt.value);

--- a/demo/questionnaires.ts
+++ b/demo/questionnaires.ts
@@ -63,7 +63,7 @@ export const medicationQuestionnaire: Questionnaire = {
     {
       linkId: "medication",
       text: "Select medication",
-      type: "choice",
+      type: "coding",
       answerOption: [
         {
           valueCoding: {
@@ -152,7 +152,7 @@ export const patientIntakeQuestionnaire: Questionnaire = {
         {
           linkId: "phone-type",
           text: "Type",
-          type: "choice",
+          type: "coding",
           answerOption: [
             { valueCoding: { code: "home", display: "Home" } },
             { valueCoding: { code: "work", display: "Work" } },

--- a/src/build/build.ts
+++ b/src/build/build.ts
@@ -37,7 +37,7 @@ export function buildQuestionnaireResponse(
   const root = new QuestionnaireResponseModel({
     id: response?.id,
     status: response?.status ?? "in-progress",
-    questionnaire: response?.questionnaire ?? questionnaire.id,
+    questionnaire: response?.questionnaire ?? questionnaire.id ?? "",
     items: [], // populated below via signal set
   });
 

--- a/src/build/fhirpath-context.ts
+++ b/src/build/fhirpath-context.ts
@@ -1,5 +1,5 @@
 import fhirpath from "fhirpath";
-import r4model from "fhirpath/fhir-context/r4";
+import r5model from "fhirpath/fhir-context/r5";
 
 export function evaluateFhirPath(
   expression: string,
@@ -9,6 +9,6 @@ export function evaluateFhirPath(
     resource,
     expression,
     { resource },
-    r4model,
+    r5model,
   ) as unknown[];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,11 @@ export {
   answerValuesMatch,
 } from "./build/extensions.js";
 
+// R4 compatibility
+export { fromR4Questionnaire, fromR4QuestionnaireResponse } from "./r4/from-r4.js";
+export { toR4Questionnaire, toR4QuestionnaireResponse } from "./r4/to-r4.js";
+export type * from "./r4/types.js";
+
 // Backwards-compatible aliases
 export { QuestionnaireResponseModel as ReactiveQuestionnaireResponse } from "./model/QuestionnaireResponse.js";
 export type { ResponseItem as ReactiveResponseItem } from "./model/ResponseItem.js";

--- a/src/model/QuestionnaireResponse.ts
+++ b/src/model/QuestionnaireResponse.ts
@@ -12,7 +12,7 @@ export class QuestionnaireResponseModel implements ResponseNode {
   readonly resourceType = "QuestionnaireResponse" as const;
   readonly id: string | undefined;
   readonly status: string;
-  readonly questionnaire: string | undefined;
+  readonly questionnaire: string;
 
   readonly #items: Signal.State<ResponseItem[]>;
   readonly itemsByLinkId: Map<string, ResponseItem[]>;
@@ -55,7 +55,7 @@ export class QuestionnaireResponseModel implements ResponseNode {
   }) {
     this.id = opts.id;
     this.status = opts.status;
-    this.questionnaire = opts.questionnaire;
+    this.questionnaire = opts.questionnaire ?? "";
     this.#items = new Signal.State(opts.items);
 
     this.itemsByLinkId = new Map();
@@ -112,10 +112,10 @@ export class QuestionnaireResponseModel implements ResponseNode {
     const result: QuestionnaireResponse = {
       resourceType: "QuestionnaireResponse",
       status: this.status,
+      questionnaire: this.questionnaire,
     };
 
     if (this.id) result.id = this.id;
-    if (this.questionnaire) result.questionnaire = this.questionnaire;
 
     const items = this.items.map((item) => item.toFhir());
     if (items.length > 0) result.item = items;

--- a/src/model/types.ts
+++ b/src/model/types.ts
@@ -1,4 +1,4 @@
-// Minimal FHIR R4 type subsets for Questionnaire + QuestionnaireResponse
+// Minimal FHIR R5 type subsets for Questionnaire + QuestionnaireResponse
 
 export type QuestionnaireItemType =
   | "group"
@@ -12,8 +12,7 @@ export type QuestionnaireItemType =
   | "string"
   | "text"
   | "url"
-  | "choice"
-  | "open-choice"
+  | "coding"
   | "attachment"
   | "reference"
   | "quantity";
@@ -107,6 +106,8 @@ export interface QuestionnaireItem {
   required?: boolean;
   readOnly?: boolean;
   repeats?: boolean;
+  answerConstraint?: "optionsOnly" | "optionsOrType" | "optionsOrString";
+  disabledDisplay?: "hidden" | "protected";
   enableWhen?: EnableWhen[];
   enableBehavior?: EnableBehavior;
   answerOption?: AnswerOption[];
@@ -138,6 +139,6 @@ export interface QuestionnaireResponse {
   resourceType: "QuestionnaireResponse";
   id?: string;
   status: string;
-  questionnaire?: string;
+  questionnaire: string;
   item?: QuestionnaireResponseItem[];
 }

--- a/src/r4/from-r4.ts
+++ b/src/r4/from-r4.ts
@@ -1,0 +1,35 @@
+import type { Questionnaire, QuestionnaireItem, QuestionnaireResponse } from "../model/types.js";
+import type { R4Questionnaire, R4QuestionnaireItem, R4QuestionnaireResponse } from "./types.js";
+
+function convertItem(r4Item: R4QuestionnaireItem): QuestionnaireItem {
+  const { item, type, ...rest } = r4Item;
+  const result: QuestionnaireItem = { ...rest, type: type as QuestionnaireItem["type"] };
+
+  if (type === "choice") {
+    result.type = "coding";
+  } else if (type === "open-choice") {
+    result.type = "coding";
+    result.answerConstraint = "optionsOrString";
+  }
+
+  if (item) {
+    result.item = item.map(convertItem);
+  }
+
+  return result;
+}
+
+export function fromR4Questionnaire(q: R4Questionnaire): Questionnaire {
+  const { item, ...rest } = q;
+  return {
+    ...rest,
+    item: item?.map(convertItem),
+  };
+}
+
+export function fromR4QuestionnaireResponse(qr: R4QuestionnaireResponse): QuestionnaireResponse {
+  return {
+    ...qr,
+    questionnaire: qr.questionnaire ?? "",
+  };
+}

--- a/src/r4/to-r4.ts
+++ b/src/r4/to-r4.ts
@@ -1,0 +1,38 @@
+import type { Questionnaire, QuestionnaireItem, QuestionnaireResponse } from "../model/types.js";
+import type { R4Questionnaire, R4QuestionnaireItem, R4QuestionnaireResponse } from "./types.js";
+
+function convertItem(r5Item: QuestionnaireItem): R4QuestionnaireItem {
+  const { answerConstraint, disabledDisplay, item, type, ...rest } = r5Item;
+  const result: R4QuestionnaireItem = { ...rest, type: type as R4QuestionnaireItem["type"] };
+
+  if (type === "coding") {
+    if (answerConstraint === "optionsOrString" || answerConstraint === "optionsOrType") {
+      result.type = "open-choice";
+    } else {
+      result.type = "choice";
+    }
+  }
+
+  if (item) {
+    result.item = item.map(convertItem);
+  }
+
+  return result;
+}
+
+export function toR4Questionnaire(q: Questionnaire): R4Questionnaire {
+  const { item, ...rest } = q;
+  return {
+    ...rest,
+    item: item?.map(convertItem),
+  };
+}
+
+export function toR4QuestionnaireResponse(qr: QuestionnaireResponse): R4QuestionnaireResponse {
+  const { questionnaire, ...rest } = qr;
+  const result: R4QuestionnaireResponse = { ...rest };
+  if (questionnaire) {
+    result.questionnaire = questionnaire;
+  }
+  return result;
+}

--- a/src/r4/types.ts
+++ b/src/r4/types.ts
@@ -1,0 +1,75 @@
+// FHIR R4 type definitions for Questionnaire + QuestionnaireResponse
+
+import type {
+  Coding,
+  Quantity,
+  Extension,
+  AnswerValue,
+  AnswerOption,
+  EnableWhen,
+  EnableWhenOperator,
+  EnableBehavior,
+  QuestionnaireResponseItem,
+  QuestionnaireResponseAnswer,
+} from "../model/types.js";
+
+export type {
+  Coding,
+  Quantity,
+  Extension,
+  AnswerValue,
+  AnswerOption,
+  EnableWhen,
+  EnableWhenOperator,
+  EnableBehavior,
+  QuestionnaireResponseItem,
+  QuestionnaireResponseAnswer,
+};
+
+export type R4QuestionnaireItemType =
+  | "group"
+  | "display"
+  | "boolean"
+  | "decimal"
+  | "integer"
+  | "date"
+  | "dateTime"
+  | "time"
+  | "string"
+  | "text"
+  | "url"
+  | "choice"
+  | "open-choice"
+  | "attachment"
+  | "reference"
+  | "quantity";
+
+export interface R4QuestionnaireItem {
+  linkId: string;
+  text?: string;
+  type: R4QuestionnaireItemType;
+  required?: boolean;
+  readOnly?: boolean;
+  repeats?: boolean;
+  enableWhen?: EnableWhen[];
+  enableBehavior?: EnableBehavior;
+  answerOption?: AnswerOption[];
+  item?: R4QuestionnaireItem[];
+  extension?: Extension[];
+}
+
+export interface R4Questionnaire {
+  resourceType: "Questionnaire";
+  id?: string;
+  status: string;
+  title?: string;
+  item?: R4QuestionnaireItem[];
+}
+
+export interface R4QuestionnaireResponse {
+  resourceType: "QuestionnaireResponse";
+  id?: string;
+  status: string;
+  questionnaire?: string;
+  item?: QuestionnaireResponseItem[];
+}

--- a/test/answer-options-toggle.test.ts
+++ b/test/answer-options-toggle.test.ts
@@ -16,7 +16,7 @@ const medicationQuestionnaire: Questionnaire = {
     {
       linkId: "medication",
       text: "Select medication",
-      type: "choice",
+      type: "coding",
       answerOption: [
         {
           valueCoding: {
@@ -232,7 +232,7 @@ describe("answerOptions with string values", () => {
         {
           linkId: "color",
           text: "Favorite color",
-          type: "choice",
+          type: "coding",
           answerOption: [
             { valueString: "Red" },
             { valueString: "Blue" },

--- a/test/enable-when.test.ts
+++ b/test/enable-when.test.ts
@@ -8,7 +8,7 @@ describe("enableWhen — equals operator", () => {
     id: "eq-test",
     status: "active",
     item: [
-      { linkId: "gender", text: "Gender", type: "choice" },
+      { linkId: "gender", text: "Gender", type: "coding" },
       {
         linkId: "pregnant",
         text: "Are you pregnant?",

--- a/test/enabled-cascade/chained-conditions.test.ts
+++ b/test/enabled-cascade/chained-conditions.test.ts
@@ -11,7 +11,7 @@ const questionnaire: Questionnaire = {
     {
       linkId: "condition-type",
       text: "Type of condition",
-      type: "choice",
+      type: "coding",
       enableWhen: [
         { question: "has-condition", operator: "=", answerBoolean: true },
       ],

--- a/test/r4/from-r4.test.ts
+++ b/test/r4/from-r4.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { fromR4Questionnaire, fromR4QuestionnaireResponse } from "../../src/r4/from-r4.js";
+import type { R4Questionnaire, R4QuestionnaireResponse } from "../../src/r4/types.js";
+
+describe("fromR4Questionnaire", () => {
+  it("converts choice to coding", () => {
+    const r4: R4Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [{ linkId: "q1", type: "choice" }],
+    };
+    const r5 = fromR4Questionnaire(r4);
+    expect(r5.item![0].type).toBe("coding");
+    expect(r5.item![0].answerConstraint).toBeUndefined();
+  });
+
+  it("converts open-choice to coding with optionsOrString", () => {
+    const r4: R4Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [{ linkId: "q1", type: "open-choice" }],
+    };
+    const r5 = fromR4Questionnaire(r4);
+    expect(r5.item![0].type).toBe("coding");
+    expect(r5.item![0].answerConstraint).toBe("optionsOrString");
+  });
+
+  it("passes through non-choice types unchanged", () => {
+    const r4: R4Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [
+        { linkId: "q1", type: "boolean" },
+        { linkId: "q2", type: "string" },
+        { linkId: "q3", type: "group", item: [{ linkId: "q3.1", type: "integer" }] },
+      ],
+    };
+    const r5 = fromR4Questionnaire(r4);
+    expect(r5.item![0].type).toBe("boolean");
+    expect(r5.item![1].type).toBe("string");
+    expect(r5.item![2].type).toBe("group");
+    expect(r5.item![2].item![0].type).toBe("integer");
+  });
+
+  it("recursively converts nested items", () => {
+    const r4: R4Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [
+        {
+          linkId: "g1",
+          type: "group",
+          item: [
+            { linkId: "q1", type: "choice" },
+            { linkId: "q2", type: "open-choice" },
+          ],
+        },
+      ],
+    };
+    const r5 = fromR4Questionnaire(r4);
+    expect(r5.item![0].item![0].type).toBe("coding");
+    expect(r5.item![0].item![0].answerConstraint).toBeUndefined();
+    expect(r5.item![0].item![1].type).toBe("coding");
+    expect(r5.item![0].item![1].answerConstraint).toBe("optionsOrString");
+  });
+});
+
+describe("fromR4QuestionnaireResponse", () => {
+  it("sets questionnaire to empty string when absent", () => {
+    const r4: R4QuestionnaireResponse = {
+      resourceType: "QuestionnaireResponse",
+      status: "in-progress",
+    };
+    const r5 = fromR4QuestionnaireResponse(r4);
+    expect(r5.questionnaire).toBe("");
+  });
+
+  it("preserves questionnaire when present", () => {
+    const r4: R4QuestionnaireResponse = {
+      resourceType: "QuestionnaireResponse",
+      status: "in-progress",
+      questionnaire: "Questionnaire/123",
+    };
+    const r5 = fromR4QuestionnaireResponse(r4);
+    expect(r5.questionnaire).toBe("Questionnaire/123");
+  });
+});

--- a/test/r4/to-r4.test.ts
+++ b/test/r4/to-r4.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { toR4Questionnaire, toR4QuestionnaireResponse } from "../../src/r4/to-r4.js";
+import { fromR4Questionnaire } from "../../src/r4/from-r4.js";
+import type { Questionnaire, QuestionnaireResponse } from "../../src/model/types.js";
+import type { R4Questionnaire } from "../../src/r4/types.js";
+
+describe("toR4Questionnaire", () => {
+  it("converts coding to choice (default answerConstraint)", () => {
+    const r5: Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [{ linkId: "q1", type: "coding" }],
+    };
+    const r4 = toR4Questionnaire(r5);
+    expect(r4.item![0].type).toBe("choice");
+  });
+
+  it("converts coding with optionsOnly to choice", () => {
+    const r5: Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [{ linkId: "q1", type: "coding", answerConstraint: "optionsOnly" }],
+    };
+    const r4 = toR4Questionnaire(r5);
+    expect(r4.item![0].type).toBe("choice");
+  });
+
+  it("converts coding with optionsOrString to open-choice", () => {
+    const r5: Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [{ linkId: "q1", type: "coding", answerConstraint: "optionsOrString" }],
+    };
+    const r4 = toR4Questionnaire(r5);
+    expect(r4.item![0].type).toBe("open-choice");
+  });
+
+  it("converts coding with optionsOrType to open-choice (lossy)", () => {
+    const r5: Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [{ linkId: "q1", type: "coding", answerConstraint: "optionsOrType" }],
+    };
+    const r4 = toR4Questionnaire(r5);
+    expect(r4.item![0].type).toBe("open-choice");
+  });
+
+  it("strips R5-only fields", () => {
+    const r5: Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [
+        {
+          linkId: "q1",
+          type: "coding",
+          answerConstraint: "optionsOrString",
+          disabledDisplay: "protected",
+        },
+      ],
+    };
+    const r4 = toR4Questionnaire(r5);
+    expect(r4.item![0]).not.toHaveProperty("answerConstraint");
+    expect(r4.item![0]).not.toHaveProperty("disabledDisplay");
+  });
+
+  it("recursively converts nested items", () => {
+    const r5: Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [
+        {
+          linkId: "g1",
+          type: "group",
+          item: [{ linkId: "q1", type: "coding", answerConstraint: "optionsOrString" }],
+        },
+      ],
+    };
+    const r4 = toR4Questionnaire(r5);
+    expect(r4.item![0].item![0].type).toBe("open-choice");
+  });
+});
+
+describe("toR4QuestionnaireResponse", () => {
+  it("omits questionnaire when empty string", () => {
+    const r5: QuestionnaireResponse = {
+      resourceType: "QuestionnaireResponse",
+      status: "in-progress",
+      questionnaire: "",
+    };
+    const r4 = toR4QuestionnaireResponse(r5);
+    expect(r4.questionnaire).toBeUndefined();
+  });
+
+  it("preserves questionnaire when non-empty", () => {
+    const r5: QuestionnaireResponse = {
+      resourceType: "QuestionnaireResponse",
+      status: "in-progress",
+      questionnaire: "Questionnaire/123",
+    };
+    const r4 = toR4QuestionnaireResponse(r5);
+    expect(r4.questionnaire).toBe("Questionnaire/123");
+  });
+});
+
+describe("round-trip", () => {
+  it("fromR4 → toR4 preserves choice questionnaire", () => {
+    const original: R4Questionnaire = {
+      resourceType: "Questionnaire",
+      status: "active",
+      item: [
+        { linkId: "q1", type: "choice" },
+        { linkId: "q2", type: "open-choice" },
+        { linkId: "q3", type: "boolean" },
+        {
+          linkId: "g1",
+          type: "group",
+          item: [{ linkId: "q4", type: "choice" }],
+        },
+      ],
+    };
+    const roundTripped = toR4Questionnaire(fromR4Questionnaire(original));
+    expect(roundTripped).toEqual(original);
+  });
+});


### PR DESCRIPTION
## Summary
- **R5 types** (`src/model/types.ts`): `choice`/`open-choice` → `coding`, added `answerConstraint` and `disabledDisplay`, `questionnaire` now required string
- **R4 compatibility** (`src/r4/`): pure `fromR4*`/`toR4*` transform functions with full test coverage including round-trip
- **Internals updated**: FHIRPath R5 context, `QuestionnaireResponse.questionnaire` required, test fixtures and demo code aligned

Closes #16, closes #17, closes #18, closes #19

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx vitest run` — all 224 tests pass (22 files), including new R4 transform tests
- [ ] Manual check: demo app renders correctly with `coding` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)