### PR TITLE
Add undo/redo history for form state

### DIFF
--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,204 @@
+import { Signal } from "@lit-labs/signals";
+import type { QuestionnaireResponseModel } from "./model/QuestionnaireResponse.js";
+import type { ResponseItem } from "./model/ResponseItem.js";
+import type { AnswerValue } from "./model/types.js";
+
+export interface HistoryOptions {
+  /** Maximum number of undo steps to keep. Default: 50 */
+  maxSize?: number;
+  /** Debounce interval in ms for auto-capture. Default: 300 */
+  debounceMs?: number;
+}
+
+type Snapshot = Map<ResponseItem, AnswerValue[] | null>;
+
+function takeSnapshot(model: QuestionnaireResponseModel): Snapshot {
+  const snapshot: Snapshot = new Map();
+  model.forEachItem((item) => {
+    if (!item.calculatedExpression) {
+      const values = item.answerValues;
+      snapshot.set(
+        item,
+        values ? (JSON.parse(JSON.stringify(values)) as AnswerValue[]) : null,
+      );
+    }
+  });
+  return snapshot;
+}
+
+function restoreSnapshot(snapshot: Snapshot): void {
+  for (const [item, values] of snapshot) {
+    item.setAnswer(values ?? []);
+  }
+}
+
+function snapshotsEqual(a: Snapshot, b: Snapshot): boolean {
+  if (a.size !== b.size) return false;
+  for (const [item, values] of a) {
+    if (!b.has(item)) return false;
+    if (JSON.stringify(values) !== JSON.stringify(b.get(item))) return false;
+  }
+  return true;
+}
+
+export class FormHistory {
+  readonly #model: QuestionnaireResponseModel;
+  readonly #maxSize: number;
+  readonly #debounceMs: number;
+
+  readonly #past: Snapshot[] = [];
+  readonly #future: Snapshot[] = [];
+  #current: Snapshot;
+  readonly #version = new Signal.State(0);
+
+  readonly #canUndo: Signal.Computed<boolean>;
+  readonly #canRedo: Signal.Computed<boolean>;
+
+  #restoring = false;
+  #debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  #watcher: Signal.subtle.Watcher;
+  #tracker: Signal.Computed<void>;
+  #disposed = false;
+
+  constructor(model: QuestionnaireResponseModel, options?: HistoryOptions) {
+    this.#model = model;
+    this.#maxSize = options?.maxSize ?? 50;
+    this.#debounceMs = options?.debounceMs ?? 300;
+
+    // Capture initial state
+    this.#current = takeSnapshot(model);
+
+    this.#canUndo = new Signal.Computed(() => {
+      this.#version.get();
+      return this.#past.length > 0;
+    });
+
+    this.#canRedo = new Signal.Computed(() => {
+      this.#version.get();
+      return this.#future.length > 0;
+    });
+
+    // Computed that tracks all non-calculated answer signals.
+    // Reading answerValues inside forEachItem creates reactive dependencies
+    // on every answer signal, so the watcher fires when any answer changes.
+    this.#tracker = new Signal.Computed<void>(() => {
+      model.forEachItem((item) => {
+        if (!item.calculatedExpression) {
+          item.answerValues;
+        }
+      });
+    });
+
+    // Initialize dependencies
+    this.#tracker.get();
+
+    // Watch for changes and schedule debounced capture
+    this.#watcher = new Signal.subtle.Watcher(() => {
+      if (!this.#restoring && !this.#disposed) {
+        this.#scheduleCapture();
+      }
+    });
+    this.#watcher.watch(this.#tracker);
+  }
+
+  /** Reactive: true when there is at least one undo step available. */
+  get canUndo(): boolean {
+    return this.#canUndo.get();
+  }
+
+  /** Reactive: true when there is at least one redo step available. */
+  get canRedo(): boolean {
+    return this.#canRedo.get();
+  }
+
+  /** Restore the previous state. No-op if nothing to undo. */
+  undo(): void {
+    if (this.#past.length === 0) return;
+
+    this.#cancelPendingCapture();
+    this.#future.push(this.#current);
+    this.#current = this.#past.pop()!;
+    this.#restore(this.#current);
+    this.#bumpVersion();
+  }
+
+  /** Re-apply the next state. No-op if nothing to redo. */
+  redo(): void {
+    if (this.#future.length === 0) return;
+
+    this.#cancelPendingCapture();
+    this.#past.push(this.#current);
+    this.#current = this.#future.pop()!;
+    this.#restore(this.#current);
+    this.#bumpVersion();
+  }
+
+  /**
+   * Immediately capture the current answer state, bypassing debounce.
+   * Useful after programmatic changes like `setResponse`.
+   */
+  captureState(): void {
+    this.#cancelPendingCapture();
+    this.#consumePending();
+    this.#pushSnapshot();
+  }
+
+  /** Clean up watchers and pending timers. */
+  dispose(): void {
+    this.#disposed = true;
+    this.#cancelPendingCapture();
+    this.#watcher.unwatch(this.#tracker);
+  }
+
+  #pushSnapshot(): void {
+    const snapshot = takeSnapshot(this.#model);
+    if (snapshotsEqual(snapshot, this.#current)) return;
+
+    this.#past.push(this.#current);
+    if (this.#past.length > this.#maxSize) {
+      this.#past.shift();
+    }
+    this.#current = snapshot;
+    this.#future.length = 0;
+    this.#bumpVersion();
+  }
+
+  #restore(snapshot: Snapshot): void {
+    this.#restoring = true;
+    try {
+      restoreSnapshot(snapshot);
+      this.#consumePending();
+    } finally {
+      this.#restoring = false;
+    }
+  }
+
+  #scheduleCapture(): void {
+    if (this.#debounceTimer !== null) {
+      clearTimeout(this.#debounceTimer);
+    }
+    this.#debounceTimer = setTimeout(() => {
+      this.#debounceTimer = null;
+      this.#consumePending();
+      this.#pushSnapshot();
+    }, this.#debounceMs);
+  }
+
+  #cancelPendingCapture(): void {
+    if (this.#debounceTimer !== null) {
+      clearTimeout(this.#debounceTimer);
+      this.#debounceTimer = null;
+    }
+  }
+
+  /** Re-evaluate pending signals so the watcher resets its dirty state. */
+  #consumePending(): void {
+    for (const s of this.#watcher.getPending()) {
+      s.get();
+    }
+  }
+
+  #bumpVersion(): void {
+    this.#version.set(this.#version.get() + 1);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,9 @@ export {
   answerValuesMatch,
 } from "./build/extensions.js";
 
+// History
+export { FormHistory, type HistoryOptions } from "./history.js";
+
 // R4 compatibility
 export { fromR4Questionnaire, fromR4QuestionnaireResponse } from "./r4/from-r4.js";
 export { toR4Questionnaire, toR4QuestionnaireResponse } from "./r4/to-r4.js";

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { buildQuestionnaireResponse } from "../src/build/build.js";
+import { FormHistory } from "../src/history.js";
+import type {
+  Questionnaire,
+  QuestionnaireResponse,
+} from "../src/model/types.js";
+
+const questionnaire: Questionnaire = {
+  resourceType: "Questionnaire",
+  id: "history-test",
+  status: "active",
+  item: [
+    { linkId: "name", text: "Name", type: "string" },
+    { linkId: "age", text: "Age", type: "integer" },
+    { linkId: "notes", text: "Notes", type: "text" },
+  ],
+};
+
+function buildModel(response?: QuestionnaireResponse) {
+  return buildQuestionnaireResponse(questionnaire, response);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("FormHistory", () => {
+  describe("initial state", () => {
+    it("canUndo is false initially", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+
+      expect(history.canUndo).toBe(false);
+      expect(history.canRedo).toBe(false);
+
+      history.dispose();
+    });
+  });
+
+  describe("captureState", () => {
+    it("captures current state as an undo point", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+      history.captureState();
+
+      expect(history.canUndo).toBe(true);
+      expect(history.canRedo).toBe(false);
+
+      history.dispose();
+    });
+
+    it("does not capture duplicate snapshots", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+
+      history.captureState();
+      history.captureState();
+
+      expect(history.canUndo).toBe(false);
+
+      history.dispose();
+    });
+  });
+
+  describe("undo", () => {
+    it("restores the previous answer state", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+      history.captureState();
+
+      name.setAnswer([{ valueString: "Bob" }]);
+      history.captureState();
+
+      history.undo();
+
+      expect(name.answerValues).toEqual([{ valueString: "Alice" }]);
+
+      history.dispose();
+    });
+
+    it("restores to empty state when undoing the first change", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+      history.captureState();
+
+      history.undo();
+
+      expect(name.answerValues).toEqual([]);
+
+      history.dispose();
+    });
+
+    it("restores multiple items", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+      const [age] = model.getItems("age");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+      age.setAnswer([{ valueInteger: 30 }]);
+      history.captureState();
+
+      name.setAnswer([{ valueString: "Bob" }]);
+      age.setAnswer([{ valueInteger: 25 }]);
+      history.captureState();
+
+      history.undo();
+
+      expect(name.answerValues).toEqual([{ valueString: "Alice" }]);
+      expect(age.answerValues).toEqual([{ valueInteger: 30 }]);
+
+      history.dispose();
+    });
+
+    it("is a no-op when nothing to undo", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+
+      history.undo();
+
+      expect(name.answerValues).toEqual([{ valueString: "Alice" }]);
+
+      history.dispose();
+    });
+  });
+
+  describe("redo", () => {
+    it("re-applies the undone state", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+      history.captureState();
+
+      history.undo();
+      expect(name.answerValues).toEqual([]);
+
+      history.redo();
+      expect(name.answerValues).toEqual([{ valueString: "Alice" }]);
+
+      history.dispose();
+    });
+
+    it("is a no-op when nothing to redo", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+
+      history.redo();
+
+      expect(history.canRedo).toBe(false);
+
+      history.dispose();
+    });
+
+    it("redo stack is cleared on new capture after undo", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+      history.captureState();
+
+      name.setAnswer([{ valueString: "Bob" }]);
+      history.captureState();
+
+      history.undo();
+      expect(history.canRedo).toBe(true);
+
+      // New change clears redo
+      name.setAnswer([{ valueString: "Charlie" }]);
+      history.captureState();
+
+      expect(history.canRedo).toBe(false);
+
+      history.dispose();
+    });
+  });
+
+  describe("multi-step undo/redo", () => {
+    it("supports multiple undo and redo steps", () => {
+      const model = buildModel();
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "A" }]);
+      history.captureState();
+
+      name.setAnswer([{ valueString: "B" }]);
+      history.captureState();
+
+      name.setAnswer([{ valueString: "C" }]);
+      history.captureState();
+
+      history.undo();
+      expect(name.answerValues).toEqual([{ valueString: "B" }]);
+
+      history.undo();
+      expect(name.answerValues).toEqual([{ valueString: "A" }]);
+
+      history.undo();
+      expect(name.answerValues).toEqual([]);
+
+      history.redo();
+      expect(name.answerValues).toEqual([{ valueString: "A" }]);
+
+      history.redo();
+      expect(name.answerValues).toEqual([{ valueString: "B" }]);
+
+      history.dispose();
+    });
+  });
+
+  describe("maxSize", () => {
+    it("evicts oldest snapshots when max size is exceeded", () => {
+      const model = buildModel();
+      const history = new FormHistory(model, { maxSize: 3 });
+      const [name] = model.getItems("name");
+
+      for (const val of ["A", "B", "C", "D"]) {
+        name.setAnswer([{ valueString: val }]);
+        history.captureState();
+      }
+
+      // Undo 3 times — that's the max we can go back
+      history.undo();
+      expect(name.answerValues).toEqual([{ valueString: "C" }]);
+
+      history.undo();
+      expect(name.answerValues).toEqual([{ valueString: "B" }]);
+
+      history.undo();
+      expect(name.answerValues).toEqual([{ valueString: "A" }]);
+
+      // Can't undo further — initial empty state was evicted
+      history.undo();
+      expect(name.answerValues).toEqual([{ valueString: "A" }]);
+
+      history.dispose();
+    });
+  });
+
+  describe("debounced auto-capture", () => {
+    it("auto-captures after debounce interval", async () => {
+      vi.useFakeTimers();
+      const model = buildModel();
+      const history = new FormHistory(model, { debounceMs: 100 });
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+
+      // Not captured yet
+      expect(history.canUndo).toBe(false);
+
+      vi.advanceTimersByTime(100);
+
+      expect(history.canUndo).toBe(true);
+
+      history.dispose();
+      vi.useRealTimers();
+    });
+
+    it("debounces rapid changes into a single snapshot", async () => {
+      vi.useFakeTimers();
+      const model = buildModel();
+      const history = new FormHistory(model, { debounceMs: 100 });
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "A" }]);
+      vi.advanceTimersByTime(50);
+
+      name.setAnswer([{ valueString: "AB" }]);
+      vi.advanceTimersByTime(50);
+
+      name.setAnswer([{ valueString: "ABC" }]);
+      vi.advanceTimersByTime(100);
+
+      // Only one undo step
+      expect(history.canUndo).toBe(true);
+
+      history.undo();
+      expect(name.answerValues).toEqual([]);
+      expect(history.canUndo).toBe(false);
+
+      history.dispose();
+      vi.useRealTimers();
+    });
+  });
+
+  describe("no capture during restore", () => {
+    it("undo does not create a new history entry", () => {
+      vi.useFakeTimers();
+      const model = buildModel();
+      const history = new FormHistory(model, { debounceMs: 100 });
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Alice" }]);
+      history.captureState();
+
+      history.undo();
+      vi.advanceTimersByTime(200);
+
+      // Should still be able to redo — no new entry was captured from the restore
+      expect(history.canRedo).toBe(true);
+      expect(history.canUndo).toBe(false);
+
+      history.dispose();
+      vi.useRealTimers();
+    });
+  });
+
+  describe("calculated expressions are excluded", () => {
+    it("does not snapshot or restore calculated items", () => {
+      const calcQuestionnaire: Questionnaire = {
+        resourceType: "Questionnaire",
+        id: "calc-test",
+        status: "active",
+        item: [
+          { linkId: "weight", text: "Weight", type: "decimal" },
+          {
+            linkId: "bmi",
+            text: "BMI",
+            type: "decimal",
+            extension: [
+              {
+                url: "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression",
+                valueExpression: {
+                  language: "text/fhirpath",
+                  expression: "%resource.item.where(linkId='weight').answer.value",
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const model = buildQuestionnaireResponse(calcQuestionnaire);
+      const history = new FormHistory(model);
+      const [weight] = model.getItems("weight");
+      const [bmi] = model.getItems("bmi");
+
+      weight.setAnswer([{ valueDecimal: 80 }]);
+      history.captureState();
+
+      // BMI is calculated — should follow weight, not be independently tracked
+      expect(bmi.answerValues).toEqual([{ valueDecimal: 80 }]);
+
+      weight.setAnswer([{ valueDecimal: 70 }]);
+      history.captureState();
+
+      history.undo();
+      expect(weight.answerValues).toEqual([{ valueDecimal: 80 }]);
+      expect(bmi.answerValues).toEqual([{ valueDecimal: 80 }]);
+
+      history.dispose();
+    });
+  });
+
+  describe("dispose", () => {
+    it("stops auto-capture after dispose", () => {
+      vi.useFakeTimers();
+      const model = buildModel();
+      const history = new FormHistory(model, { debounceMs: 100 });
+      const [name] = model.getItems("name");
+
+      history.dispose();
+
+      name.setAnswer([{ valueString: "Alice" }]);
+      vi.advanceTimersByTime(200);
+
+      expect(history.canUndo).toBe(false);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe("pre-populated response", () => {
+    it("captures initial state from a pre-populated response", () => {
+      const response: QuestionnaireResponse = {
+        resourceType: "QuestionnaireResponse",
+        status: "in-progress",
+        questionnaire: "history-test",
+        item: [
+          { linkId: "name", answer: [{ valueString: "Alice" }] },
+          { linkId: "age", answer: [{ valueInteger: 30 }] },
+        ],
+      };
+
+      const model = buildModel(response);
+      const history = new FormHistory(model);
+      const [name] = model.getItems("name");
+
+      name.setAnswer([{ valueString: "Bob" }]);
+      history.captureState();
+
+      history.undo();
+
+      expect(name.answerValues).toEqual([{ valueString: "Alice" }]);
+
+      history.dispose();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `FormHistory` class with `undo()`, `redo()`, `captureState()`, and `dispose()` API
- Auto-captures answer changes via `Signal.subtle.Watcher` with configurable debounce (default 300ms)
- Reactive `canUndo`/`canRedo` getters backed by `Signal.Computed`
- Configurable max history size (default 50), guards against feedback loops during restore
- Calculated expressions are excluded from snapshot/restore
- 18 tests covering undo/redo, debounce, max size, calculated exclusion, and dispose

Closes #2

## Test plan
- [x] All 18 new history tests pass
- [x] Full suite (242 tests) passes
- [x] TypeScript typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)