### PR TITLE
Add React binding layer with signal-to-React hooks

### DIFF
--- a/docs/react-bindings.md
+++ b/docs/react-bindings.md
@@ -1,0 +1,125 @@
+# React Bindings
+
+Thin React hooks that subscribe to TC39 Signals from the core library and trigger re-renders on change. Imported from a separate entry point to keep the core framework-agnostic.
+
+```ts
+import { useEnabled, useAnswerValues } from "fhir-reactive-questionnaire-response/react";
+```
+
+React >=18 is required (uses `useState` and `useEffect`). It is an optional peer dependency — the core library works without React.
+
+## How it works
+
+The bridge between TC39 Signals and React is `useSignalValue`:
+
+```
+useSignalValue(compute)
+  │
+  ├─ creates a Signal.Computed that runs `compute()`
+  │   → auto-tracks every signal read during execution
+  │
+  ├─ creates a Signal.subtle.Watcher that observes the computed
+  │   → when any tracked signal changes, the watcher fires
+  │
+  └─ watcher callback calls useState setter → React re-renders
+      → during render, computed.get() returns the new value
+```
+
+All other hooks are one-line wrappers around `useSignalValue`. For example:
+
+```ts
+function useEnabled(item: ResponseItem): boolean {
+  return useSignalValue(() => item.enabled);
+}
+```
+
+This means every hook automatically tracks exactly the signals it reads — no manual dependency arrays, no over-subscription.
+
+## Providing the model
+
+Wrap your form tree in a context provider:
+
+```tsx
+import { buildQuestionnaireResponse } from "fhir-reactive-questionnaire-response";
+import { QuestionnaireResponseContext } from "fhir-reactive-questionnaire-response/react";
+
+function App() {
+  const [model] = useState(() => buildQuestionnaireResponse(questionnaire, response));
+
+  return (
+    <QuestionnaireResponseContext.Provider value={model}>
+      <MyForm />
+    </QuestionnaireResponseContext.Provider>
+  );
+}
+```
+
+## Hook reference
+
+### Context
+
+| Hook | Returns | Description |
+|---|---|---|
+| `useQuestionnaireResponse()` | `QuestionnaireResponseModel` | Access the model from context. Throws outside a provider. |
+
+### Item lookup
+
+| Hook | Returns | Description |
+|---|---|---|
+| `useResponseItem(linkId)` | `ResponseItem \| undefined` | First item instance by linkId |
+| `useResponseItemById(id)` | `ResponseItem \| undefined` | Item by unique instance ID |
+
+### Reactive state
+
+| Hook | Returns | Description |
+|---|---|---|
+| `useEnabled(item)` | `boolean` | enableWhen evaluation result |
+| `useVisible(item)` | `boolean` | Visible = enabled OR disabledDisplay !== "hidden" |
+| `useAnswerValues(item)` | `AnswerValue[] \| null` | Current answer values |
+| `useAnswerEntries(item)` | `ResponseAnswer[]` | Answer entries with nested children (answer[].item[] pattern) |
+| `useAnswerOptions(item)` | `AnswerOption[]` | Enabled answer options (filtered by toggle expressions) |
+| `useValidation(item)` | `{ valid, errors }` | Validation state (required, answerConstraint) |
+| `useVisibleChildren(item)` | `ResponseItem[]` | Visible child items |
+| `useVisibleAnswerChildren(entry)` | `ResponseItem[]` | Visible children of a ResponseAnswer |
+| `useDirty(item)` | `boolean` | Has the answer changed from its initial value? |
+| `useTouched(item)` | `boolean` | Has the user interacted with this item? |
+
+### Primitive
+
+| Hook | Returns | Description |
+|---|---|---|
+| `useSignalValue(compute)` | `T` | Subscribe to any signal-derived value. Use this to read signals not covered by the built-in hooks. |
+
+## Example: a text input
+
+```tsx
+import { useResponseItem, useAnswerValues, useValidation } from "fhir-reactive-questionnaire-response/react";
+
+function TextInput({ linkId }: { linkId: string }) {
+  const item = useResponseItem(linkId);
+  if (!item) return null;
+
+  const answers = useAnswerValues(item);
+  const { valid, errors } = useValidation(item);
+  const value = answers?.[0]?.valueString ?? "";
+
+  return (
+    <div>
+      <label>{item.text}</label>
+      <input
+        value={value}
+        readOnly={item.readOnly}
+        onChange={(e) => item.setAnswer([{ valueString: e.target.value }])}
+        onBlur={() => item.markTouched()}
+      />
+      {item.touched && !valid && (
+        <span className="error">{errors[0]?.message}</span>
+      )}
+    </div>
+  );
+}
+```
+
+## Why not `useSyncExternalStore`?
+
+The TC39 Signal polyfill throws `producerAccessed` errors when signals are read during `getSnapshot` in certain React render phases. The simpler `Watcher` + `useState` approach avoids this by separating notification (watcher callback sets state) from reading (computed.get() during render).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,13 @@
         "fhirpath": "^3.17.0"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^25.2.3",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
+        "jsdom": "^29.0.1",
         "lit": "^3.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -23,7 +26,76 @@
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
         "vitest": "^3.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -267,6 +339,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -313,6 +395,161 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -755,6 +992,24 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -1207,6 +1462,62 @@
         "win32"
       ]
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1305,6 +1616,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1464,6 +1776,29 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/antlr4": {
       "version": "4.9.3",
       "resolved": "https://registry.npmjs.org/antlr4/-/antlr4-4.9.3.tgz",
@@ -1489,6 +1824,16 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1507,6 +1852,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -1683,6 +2038,20 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -1703,6 +2072,20 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "lodash.get": "~4.4.2"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/date-fns": {
@@ -1729,6 +2112,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -1738,6 +2128,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -1752,6 +2159,19 @@
       "integrity": "sha512-QdXO3nXOzZB4pAjM0n6ZE+R9/+kPpECA/XSELIcc54NeYVnBqIk+4DFiBgK+8QbV3mdvTG6nedl7dTYgO+5wDw==",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-module-lexer": {
@@ -1935,6 +2355,19 @@
       "license": "ISC",
       "optional": true
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1961,6 +2394,13 @@
       "dependencies": {
         "is-finite": "^1.0.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -1996,6 +2436,58 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@asamuzakjp/dom-selector": "^7.0.3",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2118,6 +2610,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2127,6 +2629,13 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mlly": {
       "version": "1.8.0",
@@ -2196,6 +2705,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -2226,6 +2748,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2328,11 +2851,36 @@
         }
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/react": {
       "version": "19.2.4",
@@ -2351,12 +2899,20 @@
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -2395,6 +2951,16 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2463,6 +3029,19 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.6.tgz",
       "integrity": "sha512-8zci48uUQyfqynGDSkUMD7FCJB96hwLnlZOXlgs1l3TX+LW27t3psSWKUxC0fxVgA86i8tL4NwGcY1h/6t3ESg==",
       "license": "ISC"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -2614,6 +3193,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -2696,6 +3282,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.27"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tree-kill": {
@@ -2789,6 +3421,16 @@
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
+      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.16.0",
@@ -3490,6 +4132,54 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3506,6 +4196,23 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmldoc": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -5,22 +5,43 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./react": {
+      "import": "./dist/react.js",
+      "types": "./dist/react.d.ts"
+    }
+  },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts src/react.ts --format esm --dts",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
     "demo": "vite"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@lit-labs/signals": "^0.2.0",
     "fhirpath": "^3.17.0"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25.2.3",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
+    "jsdom": "^29.0.1",
     "lit": "^3.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,0 +1,22 @@
+// React bindings for fhir-reactive-questionnaire-response
+// Import from "fhir-reactive-questionnaire-response/react"
+
+export { useSignalValue } from "./react/use-signal-value.js";
+export {
+  QuestionnaireResponseContext,
+  useQuestionnaireResponse,
+} from "./react/context.js";
+export {
+  useResponseItem,
+  useResponseItemById,
+  useEnabled,
+  useVisible,
+  useAnswerValues,
+  useAnswerEntries,
+  useAnswerOptions,
+  useValidation,
+  useVisibleChildren,
+  useVisibleAnswerChildren,
+  useDirty,
+  useTouched,
+} from "./react/hooks.js";

--- a/src/react/context.ts
+++ b/src/react/context.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+import type { QuestionnaireResponseModel } from "../model/QuestionnaireResponse.js";
+
+export const QuestionnaireResponseContext =
+  createContext<QuestionnaireResponseModel | null>(null);
+
+/**
+ * Access the QuestionnaireResponseModel from context.
+ * Must be used within a QuestionnaireResponseContext.Provider.
+ */
+export function useQuestionnaireResponse(): QuestionnaireResponseModel {
+  const model = useContext(QuestionnaireResponseContext);
+  if (!model) {
+    throw new Error(
+      "useQuestionnaireResponse must be used within a QuestionnaireResponseContext.Provider",
+    );
+  }
+  return model;
+}

--- a/src/react/hooks.ts
+++ b/src/react/hooks.ts
@@ -1,0 +1,101 @@
+import type { ResponseItem } from "../model/ResponseItem.js";
+import type { ResponseAnswer } from "../model/ResponseAnswer.js";
+import type { AnswerOption } from "../model/AnswerOption.js";
+import type { AnswerValue, ValidationError } from "../model/types.js";
+import { useQuestionnaireResponse } from "./context.js";
+import { useSignalValue } from "./use-signal-value.js";
+
+/**
+ * Look up a response item by linkId.
+ * Returns the first instance (use the model directly for repeating items).
+ */
+export function useResponseItem(linkId: string): ResponseItem | undefined {
+  const model = useQuestionnaireResponse();
+  return useSignalValue(() => model.getItems(linkId)[0]);
+}
+
+/**
+ * Look up a response item by its unique instance ID.
+ */
+export function useResponseItemById(id: string): ResponseItem | undefined {
+  const model = useQuestionnaireResponse();
+  return useSignalValue(() => model.getItemById(id));
+}
+
+/**
+ * Subscribe to an item's enabled state.
+ */
+export function useEnabled(item: ResponseItem): boolean {
+  return useSignalValue(() => item.enabled);
+}
+
+/**
+ * Subscribe to an item's visibility (enabled OR disabledDisplay !== "hidden").
+ */
+export function useVisible(item: ResponseItem): boolean {
+  return useSignalValue(() => item.visible);
+}
+
+/**
+ * Subscribe to an item's answer values.
+ */
+export function useAnswerValues(item: ResponseItem): AnswerValue[] | null {
+  return useSignalValue(() => item.answerValues);
+}
+
+/**
+ * Subscribe to an item's answer entries (for items with answer[].item[] pattern).
+ */
+export function useAnswerEntries(item: ResponseItem): ResponseAnswer[] {
+  return useSignalValue(() => item.answerEntries);
+}
+
+/**
+ * Subscribe to an item's enabled answer options (filtered by toggle expressions).
+ */
+export function useAnswerOptions(item: ResponseItem): AnswerOption[] {
+  return useSignalValue(() => item.enabledAnswerOptions);
+}
+
+/**
+ * Subscribe to an item's validation state.
+ */
+export function useValidation(item: ResponseItem): {
+  valid: boolean;
+  errors: readonly ValidationError[];
+} {
+  return useSignalValue(() => ({
+    valid: item.valid,
+    errors: item.errors,
+  }));
+}
+
+/**
+ * Subscribe to an item's visible children.
+ */
+export function useVisibleChildren(item: ResponseItem): ResponseItem[] {
+  return useSignalValue(() => item.visibleItems);
+}
+
+/**
+ * Subscribe to a response answer entry's visible children.
+ */
+export function useVisibleAnswerChildren(
+  entry: ResponseAnswer,
+): ResponseItem[] {
+  return useSignalValue(() => entry.visibleItems);
+}
+
+/**
+ * Subscribe to an item's dirty state.
+ */
+export function useDirty(item: ResponseItem): boolean {
+  return useSignalValue(() => item.dirty);
+}
+
+/**
+ * Subscribe to an item's touched state.
+ */
+export function useTouched(item: ResponseItem): boolean {
+  return useSignalValue(() => item.touched);
+}

--- a/src/react/use-signal-value.ts
+++ b/src/react/use-signal-value.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect, useRef } from "react";
+import { Signal } from "@lit-labs/signals";
+
+/**
+ * Subscribe to a signal-derived value and re-render when it changes.
+ *
+ * The `compute` function is called inside a `Signal.Computed` context,
+ * so any signals read during execution are automatically tracked.
+ * When any tracked signal changes, the component re-renders.
+ */
+export function useSignalValue<T>(compute: () => T): T {
+  const computeRef = useRef(compute);
+  computeRef.current = compute;
+
+  const [, forceRender] = useState(0);
+
+  const stateRef = useRef<{
+    computed: Signal.Computed<T>;
+    watcher: Signal.subtle.Watcher;
+  } | null>(null);
+
+  if (stateRef.current === null) {
+    const computed = new Signal.Computed(() => computeRef.current());
+    const watcher = new Signal.subtle.Watcher(() => {
+      forceRender((n) => n + 1);
+    });
+    watcher.watch(computed);
+    stateRef.current = { computed, watcher };
+  }
+
+  useEffect(() => {
+    const { watcher, computed } = stateRef.current!;
+    // Ensure the watcher is active
+    watcher.watch(computed);
+    return () => {
+      watcher.unwatch(computed);
+    };
+  }, []);
+
+  const { computed, watcher } = stateRef.current;
+  // Read the value and clear any pending notifications
+  const value = computed.get();
+  watcher.getPending();
+  return value;
+}

--- a/test/react/hooks.test.tsx
+++ b/test/react/hooks.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { renderHook, act } from "@testing-library/react";
+import { buildQuestionnaireResponse } from "../../src/build/build.js";
+import { QuestionnaireResponseContext } from "../../src/react/context.js";
+import {
+  useQuestionnaireResponse,
+  useResponseItem,
+  useEnabled,
+  useVisible,
+  useAnswerValues,
+  useAnswerOptions,
+  useValidation,
+  useVisibleChildren,
+  useDirty,
+  useTouched,
+} from "../../src/react.js";
+import type { Questionnaire } from "../../src/model/types.js";
+import type { QuestionnaireResponseModel } from "../../src/model/QuestionnaireResponse.js";
+
+const TOGGLE_EXT_URL =
+  "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-answerOptionsToggleExpression";
+
+const questionnaire: Questionnaire = {
+  resourceType: "Questionnaire",
+  id: "react-hooks-test",
+  status: "active",
+  item: [
+    { linkId: "name", text: "Name", type: "string", required: true },
+    {
+      linkId: "conditional",
+      text: "Conditional",
+      type: "string",
+      disabledDisplay: "hidden",
+      enableWhen: [
+        { question: "name", operator: "exists", answerBoolean: true },
+      ],
+    },
+    {
+      linkId: "parent",
+      text: "Parent group",
+      type: "group",
+      item: [
+        {
+          linkId: "child-hidden",
+          text: "Hidden child",
+          type: "string",
+          disabledDisplay: "hidden",
+          enableWhen: [
+            { question: "name", operator: "exists", answerBoolean: true },
+          ],
+        },
+        {
+          linkId: "child-always",
+          text: "Always visible",
+          type: "string",
+        },
+      ],
+    },
+    {
+      linkId: "meds",
+      text: "Medications",
+      type: "coding",
+      answerOption: [
+        { valueCoding: { code: "aspirin", display: "Aspirin" } },
+        { valueCoding: { code: "tylenol", display: "Tylenol" } },
+      ],
+      extension: [
+        {
+          url: TOGGLE_EXT_URL,
+          extension: [
+            {
+              url: "option",
+              valueCoding: { code: "aspirin", display: "Aspirin" },
+            },
+            {
+              url: "expression",
+              valueExpression: {
+                language: "text/fhirpath",
+                expression:
+                  "%resource.item.where(linkId='name').answer.value.exists()",
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function createWrapper(model: QuestionnaireResponseModel) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(
+      QuestionnaireResponseContext.Provider,
+      { value: model },
+      children,
+    );
+  };
+}
+
+describe("React hooks", () => {
+  describe("useQuestionnaireResponse", () => {
+    it("returns the model from context", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const { result } = renderHook(() => useQuestionnaireResponse(), {
+        wrapper: createWrapper(model),
+      });
+      expect(result.current).toBe(model);
+    });
+
+    it("throws outside provider", () => {
+      expect(() => {
+        renderHook(() => useQuestionnaireResponse());
+      }).toThrow("useQuestionnaireResponse must be used within");
+    });
+  });
+
+  describe("useResponseItem", () => {
+    it("returns item by linkId", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const { result } = renderHook(() => useResponseItem("name"), {
+        wrapper: createWrapper(model),
+      });
+      expect(result.current?.linkId).toBe("name");
+    });
+
+    it("returns undefined for unknown linkId", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const { result } = renderHook(() => useResponseItem("unknown"), {
+        wrapper: createWrapper(model),
+      });
+      expect(result.current).toBeUndefined();
+    });
+  });
+
+  describe("useEnabled", () => {
+    it("tracks enabled state reactively", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const conditional = model.getItems("conditional")[0];
+      const name = model.getItems("name")[0];
+
+      const { result } = renderHook(() => useEnabled(conditional), {
+        wrapper: createWrapper(model),
+      });
+
+      expect(result.current).toBe(false);
+
+      act(() => {
+        name.setAnswer([{ valueString: "Alice" }]);
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("useVisible", () => {
+    it("tracks visibility reactively", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const conditional = model.getItems("conditional")[0];
+      const name = model.getItems("name")[0];
+
+      const { result } = renderHook(() => useVisible(conditional), {
+        wrapper: createWrapper(model),
+      });
+
+      // hidden because disabled + disabledDisplay="hidden"
+      expect(result.current).toBe(false);
+
+      act(() => {
+        name.setAnswer([{ valueString: "Alice" }]);
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("useAnswerValues", () => {
+    it("tracks answer changes", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const name = model.getItems("name")[0];
+
+      const { result } = renderHook(() => useAnswerValues(name), {
+        wrapper: createWrapper(model),
+      });
+
+      expect(result.current).toEqual([]);
+
+      act(() => {
+        name.setAnswer([{ valueString: "Bob" }]);
+      });
+      expect(result.current).toEqual([{ valueString: "Bob" }]);
+    });
+  });
+
+  describe("useAnswerOptions", () => {
+    it("returns filtered enabled options", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const meds = model.getItems("meds")[0];
+      const name = model.getItems("name")[0];
+
+      const { result } = renderHook(() => useAnswerOptions(meds), {
+        wrapper: createWrapper(model),
+      });
+
+      // aspirin is toggled off (name has no answer)
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].value.valueCoding?.code).toBe("tylenol");
+
+      act(() => {
+        name.setAnswer([{ valueString: "test" }]);
+      });
+      expect(result.current).toHaveLength(2);
+    });
+  });
+
+  describe("useValidation", () => {
+    it("tracks validation state", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const name = model.getItems("name")[0];
+
+      const { result } = renderHook(() => useValidation(name), {
+        wrapper: createWrapper(model),
+      });
+
+      expect(result.current.valid).toBe(false);
+      expect(result.current.errors).toHaveLength(1);
+
+      act(() => {
+        name.setAnswer([{ valueString: "Alice" }]);
+      });
+      expect(result.current.valid).toBe(true);
+      expect(result.current.errors).toHaveLength(0);
+    });
+  });
+
+  describe("useVisibleChildren", () => {
+    it("returns only visible children", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const parent = model.getItems("parent")[0];
+
+      const { result } = renderHook(() => useVisibleChildren(parent), {
+        wrapper: createWrapper(model),
+      });
+
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].linkId).toBe("child-always");
+    });
+  });
+
+  describe("useDirty", () => {
+    it("tracks dirty state", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const name = model.getItems("name")[0];
+
+      const { result } = renderHook(() => useDirty(name), {
+        wrapper: createWrapper(model),
+      });
+
+      expect(result.current).toBe(false);
+
+      act(() => {
+        name.setAnswer([{ valueString: "changed" }]);
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+
+  describe("useTouched", () => {
+    it("tracks touched state", () => {
+      const model = buildQuestionnaireResponse(questionnaire);
+      const name = model.getItems("name")[0];
+
+      const { result } = renderHook(() => useTouched(name), {
+        wrapper: createWrapper(model),
+      });
+
+      expect(result.current).toBe(false);
+
+      act(() => {
+        name.markTouched();
+      });
+      expect(result.current).toBe(true);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["test/**/*.test.ts"],
+    include: ["test/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary
Introduces a thin React binding package at `fhir-reactive-questionnaire-response/react` that bridges TC39 Signals to React.

### Core primitive
- **`useSignalValue(compute)`** — subscribes to any signals read during `compute()` via `Signal.subtle.Watcher`, triggers re-render on change

### Context
- **`QuestionnaireResponseContext`** — React context for the model
- **`useQuestionnaireResponse()`** — access the model from context

### Per-item hooks
- **`useResponseItem(linkId)`** / **`useResponseItemById(id)`** — item lookup
- **`useEnabled(item)`** — enabled state
- **`useVisible(item)`** — visibility (enabled OR disabledDisplay !== "hidden")
- **`useAnswerValues(item)`** — current answer values
- **`useAnswerEntries(item)`** — answer entries with nested items
- **`useAnswerOptions(item)`** — enabled answer options (filtered by toggle expressions)
- **`useValidation(item)`** — { valid, errors }
- **`useVisibleChildren(item)`** — visible child items
- **`useVisibleAnswerChildren(entry)`** — visible children of a ResponseAnswer
- **`useDirty(item)`** / **`useTouched(item)`** — form state

### Package setup
- Separate entry point: `import { useEnabled } from "fhir-reactive-questionnaire-response/react"`
- React is an optional peer dependency (>=18.0.0)
- Build produces `dist/react.js` (2.7KB) alongside `dist/index.js`

## Test plan
- [x] 12 tests in `test/react/hooks.test.tsx` using @testing-library/react + jsdom
- [x] All 295 tests pass (including all existing tests)
- [x] Build produces both entry points correctly

Closes #26, #27, #28, #29, #30, #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)